### PR TITLE
Fix Netlify deployment failure for recent commits

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
 # Production builds (on Netlify servers)
 [build]
   publish = "_site"
-  command = "JEKYLL_ENV=production bundle exec jekyll build"
+  command = "bundle install && JEKYLL_ENV=production bundle exec jekyll build"
 
 [build.environment]
   JEKYLL_ENV = "production"


### PR DESCRIPTION
Le déploiement échouait avec l'erreur "bundler: command not found: jekyll" car Netlify ne fait plus automatiquement bundle install avant d'exécuter la commande de build.

Solution: Ajouter explicitement "bundle install &&" à la commande de build dans netlify.toml pour garantir que toutes les gems (notamment Jekyll) sont installées avant le build.